### PR TITLE
M4 Mac Mini results

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,5 +28,6 @@ The compileJava is the total time and the bootRun is the startup time, e.g:
 | M2 Pro  xxxxxxx  |                  |                  |                     |                     |                             | MacOS               |
 | M3 Pro           | 650ms            | 1.490s           | 79s (1m 19s)        | 20.5ms              | M3 Pro 12c 36GB (6p,6e)     | MacOS               |
 | M3 Max           | 620ms            | 1.429s           | 66s (1m 6s)         | 20.4ms              | M3 Max 16c 48GB             | MacOS               |
+| M4               | 668ms            | 1.29s            | 137s (2m 17s)       | 16ms                | M4 10c 32GB (4p,6e)         | MacOS               |
 | M4 Pro           | 607ms            | 1.281s           | 81s (1m 41s)        | 17.2ms              | M4 Pro 14c 48GB (10p,4e)    | MacOS               |
 | ITX Computer     | 1000ms           | 2.410s           | 186s (2m 46s)       | 17.2ms              | Ryzen 5700g 8c 16t 32GB     | Pop!\_OS 22.04 LTS  |

--- a/README.md
+++ b/README.md
@@ -28,6 +28,6 @@ The compileJava is the total time and the bootRun is the startup time, e.g:
 | M2 Pro  xxxxxxx  |                  |                  |                     |                     |                             | MacOS               |
 | M3 Pro           | 650ms            | 1.490s           | 79s (1m 19s)        | 20.5ms              | M3 Pro 12c 36GB (6p,6e)     | MacOS               |
 | M3 Max           | 620ms            | 1.429s           | 66s (1m 6s)         | 20.4ms              | M3 Max 16c 48GB             | MacOS               |
-| M4               | 668ms            | 1.29s            | 137s (2m 17s)       | 16ms                | M4 10c 32GB (4p,6e)         | MacOS               |
+| M4 Mac Mini      | 668ms            | 1.29s            | 137s (2m 17s)       | 16ms                | M4 10c 32GB (4p,6e)         | MacOS               |
 | M4 Pro           | 607ms            | 1.281s           | 81s (1m 41s)        | 17.2ms              | M4 Pro 14c 48GB (10p,4e)    | MacOS               |
 | ITX Computer     | 1000ms           | 2.410s           | 186s (2m 46s)       | 17.2ms              | Ryzen 5700g 8c 16t 32GB     | Pop!\_OS 22.04 LTS  |


### PR DESCRIPTION
Added M4 Mac mini results

Proof:
![Screenshot 2024-11-16 at 9 50 11 PM](https://github.com/user-attachments/assets/a1528a43-b01f-4952-8c0a-28ad8b6f5c96)
![Screenshot 2024-11-16 at 9 50 23 PM](https://github.com/user-attachments/assets/97b7290e-468a-48f6-830c-2d84bf89ce3f)
![Screenshot 2024-11-16 at 9 52 50 PM](https://github.com/user-attachments/assets/68aaad80-61f4-4dc2-a0ff-58a6647cb2ab)
![Screenshot 2024-11-16 at 9 53 37 PM](https://github.com/user-attachments/assets/0b8e2d90-a65d-4bcb-8e35-c2cc3e405482)
