### PR TITLE
updated m4 results

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,6 @@ The compileJava is the total time and the bootRun is the startup time, e.g:
 | M2 Pro  xxxxxxx  |                  |                  |                     |                     |                             | MacOS               |
 | M3 Pro           | 650ms            | 1.490s           | 79s (1m 19s)        | 20.5ms              | M3 Pro 12c 36GB (6p,6e)     | MacOS               |
 | M3 Max           | 620ms            | 1.429s           | 66s (1m 6s)         | 20.4ms              | M3 Max 16c 48GB             | MacOS               |
-| M4 Mac Mini      | 668ms            | 1.29s            | 137s (2m 17s)       | 16ms                | M4 10c 32GB (4p,6e)         | MacOS               |
+| M4 Mac Mini      | 650ms            | 1.253s           | 125s (2m 5s)        | 158ms               | M4 10c 32GB (4p,6e)         | MacOS               |
 | M4 Pro           | 607ms            | 1.281s           | 81s (1m 41s)        | 17.2ms              | M4 Pro 14c 48GB (10p,4e)    | MacOS               |
 | ITX Computer     | 1000ms           | 2.410s           | 186s (2m 46s)       | 17.2ms              | Ryzen 5700g 8c 16t 32GB     | Pop!\_OS 22.04 LTS  |


### PR DESCRIPTION
Gonna update the results of the m4 mac mini test. Was a bit suspicious of them and realized it was because I was screen sharing to Harman while I was running the tests which slowed it down a noticeable amount.

Proof:
![Screenshot 2024-11-17 at 10 14 56 AM](https://github.com/user-attachments/assets/012ed170-238a-4cdd-be2d-cd563d2eb582)
![Screenshot 2024-11-17 at 10 15 06 AM](https://github.com/user-attachments/assets/ac1c6f61-6a20-4e5c-aca4-2caed614c912)
![Screenshot 2024-11-17 at 10 15 27 AM](https://github.com/user-attachments/assets/76607b47-089d-47ec-a059-e1e1665c6ab6)
![Screenshot 2024-11-17 at 10 15 57 AM](https://github.com/user-attachments/assets/3ee5d4fe-5148-43b4-bb1e-8c7714332457)
